### PR TITLE
fix error when playing multimedia file on linux

### DIFF
--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -95,7 +95,7 @@ const state: BackState = {
         defaultMapping: DefaultCommandMapping,
         commandsMapping: [],
     },
-    vlcPlayer: createErrorProxy("vlcPlayer"),
+    vlcPlayer: undefined,
 };
 
 export const preferencesFilename = "preferences.json";


### PR DESCRIPTION
bugfix: error was thrown when vlcPlayer was not initialized, which by design was initialized only on the windows, removeing wrapper createErrorProxy from vlcPlayer fix that