### PR TITLE
feat: splash screen now handles errors during initialization process

### DIFF
--- a/src/renderer/components/SplashScreen.tsx
+++ b/src/renderer/components/SplashScreen.tsx
@@ -1,33 +1,80 @@
+import { englishTranslation } from "@renderer/lang/en";
 import * as React from "react";
 
 export type SplashScreenProps = {
     gamesLoaded: boolean;
     playlistsLoaded: boolean;
     miscLoaded: boolean;
+    errorMessage?: string;
+    onGoToConfig?: () => void;
 };
 
 export function SplashScreen(props: SplashScreenProps) {
-    const { gamesLoaded, playlistsLoaded, miscLoaded } = props;
-    const extraClass =
-        gamesLoaded && playlistsLoaded && miscLoaded
-            ? " splash-screen--fade-out"
-            : "";
+    const {
+        gamesLoaded,
+        playlistsLoaded,
+        miscLoaded,
+        errorMessage,
+        onGoToConfig,
+    } = props;
+    const strings = englishTranslation.splash;
+    const [dismissed, setDismissed] = React.useState(false);
+
+    const allLoaded = gamesLoaded && playlistsLoaded && miscLoaded;
+    const shouldFadeOut = allLoaded || dismissed;
+    const extraClass = shouldFadeOut ? " splash-screen--fade-out" : "";
+
+    const handleGoToConfig = () => {
+        setDismissed(true);
+        onGoToConfig?.();
+    };
+
     return (
         <div className={"splash-screen" + extraClass}>
             <div className="splash-screen__logo fp-logo-box">
                 <div className="exo-logo" />
             </div>
             <div className="splash-screen__status-block">
-                <div className="splash-screen__status-header">Loading</div>
-                {!gamesLoaded ? (
-                    <div className="splash-screen__status">Games</div>
-                ) : undefined}
-                {!playlistsLoaded ? (
-                    <div className="splash-screen__status">Playlists</div>
-                ) : undefined}
-                {!miscLoaded ? (
-                    <div className="splash-screen__status">Misc</div>
-                ) : undefined}
+                {errorMessage && !dismissed ? (
+                    <>
+                        <div className="splash-screen__status-header splash-screen__status-header--error">
+                            {strings.errorLoading}
+                        </div>
+                        <div className="splash-screen__status splash-screen__status--error">
+                            {errorMessage || strings.unknownError}
+                        </div>
+                        <div className="splash-screen__hint">
+                            {strings.configHint}
+                        </div>
+                        <button
+                            className="splash-screen__button"
+                            onClick={handleGoToConfig}
+                        >
+                            {strings.goToConfig}
+                        </button>
+                    </>
+                ) : (
+                    <>
+                        <div className="splash-screen__status-header">
+                            {strings.loading}
+                        </div>
+                        {!gamesLoaded ? (
+                            <div className="splash-screen__status">
+                                {strings.games}
+                            </div>
+                        ) : undefined}
+                        {!playlistsLoaded ? (
+                            <div className="splash-screen__status">
+                                {strings.playlists}
+                            </div>
+                        ) : undefined}
+                        {!miscLoaded ? (
+                            <div className="splash-screen__status">
+                                {strings.misc}
+                            </div>
+                        ) : undefined}
+                    </>
+                )}
             </div>
         </div>
     );

--- a/src/renderer/lang/en.ts
+++ b/src/renderer/lang/en.ts
@@ -416,6 +416,16 @@ export const englishTranslation = {
         arcade: "Games",
         theatre: "Animations",
     },
+    splash: {
+        loading: "Loading",
+        games: "Games",
+        playlists: "Playlists",
+        misc: "Misc",
+        errorLoading: "Error Loading",
+        unknownError: "An unknown error occurred",
+        configHint: "Please check the paths on the Config page.",
+        goToConfig: "Go to Config",
+    },
     upgrades: {
         infinity: "eXoDOS Infinity",
         infinityDesc: "Required files. Adds support for Flash games.",

--- a/src/renderer/redux/gamesSlice.ts
+++ b/src/renderer/redux/gamesSlice.ts
@@ -9,12 +9,14 @@ export enum GamesInitState {
     WAITING = 0,
     LOADING,
     LOADED,
+    ERROR,
 }
 
 export type GamesState = {
     initState: GamesInitState;
     totalGames: number;
     libraries: string[];
+    errorMessage?: string;
 } & IGameCollection;
 
 export type GameUpdatedAction = {
@@ -35,6 +37,7 @@ const initialState: GamesState = {
     initState: GamesInitState.WAITING,
     totalGames: 0,
     libraries: [],
+    errorMessage: undefined,
 };
 
 const gamesSlice = createSlice({
@@ -78,6 +81,13 @@ const gamesSlice = createSlice({
         ) => {
             state.addApps = [...state.addApps, payload.addApp];
         },
+        setInitError: (
+            state: GamesState,
+            { payload }: PayloadAction<string>
+        ) => {
+            state.initState = GamesInitState.ERROR;
+            state.errorMessage = payload;
+        },
     },
 });
 
@@ -87,5 +97,6 @@ export const {
     setGames,
     updateGame,
     addAddAppsForGame,
+    setInitError,
 } = gamesSlice.actions;
 export default gamesSlice.reducer;

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -1911,6 +1911,37 @@ body {
 .splash-screen__status-header {
   font-size: 2.5rem;
 }
+.splash-screen__status-header--error {
+  color: #e74c3c;
+}
+.splash-screen__status--error {
+  color: #e74c3c;
+  max-width: 600px;
+  word-wrap: break-word;
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-size: 1.1rem;
+  line-height: 1.4;
+}
+.splash-screen__hint {
+  margin-top: 1.5rem;
+  font-size: 1rem;
+  color: #888;
+}
+.splash-screen__button {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+.splash-screen__button:hover {
+  background-color: #2980b9;
+}
 
 /** Game Image Carousel */
 .game-image-carousel-selected {


### PR DESCRIPTION
When error is thrown on the splash screen, it will be displayed and will suggest to check paths in config page. There is possibility to navigate to config page afterwards.