### PR TITLE
package.json - define 7za as universal for macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,11 @@
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3",
         "typescript-eslint": "8.48.1"
+    },
+    "build": {
+        "mac": {
+            "target": "universal",
+            "x64ArchFiles": "**/7za"
+        }
     }
 }


### PR DESCRIPTION
Prevents lipo from attempting to merge 7za, a package that is already universal
This will hopefully fix the MacOS build pipeline.