### PR TITLE
fix/Update gulpfile.js - MacOS 7za universal fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,6 +109,7 @@ gulp.task("pack", (done) => {
                 },
                 mac: {
                     icon: "./icons/icon.icns",
+                    x64ArchFiles: "**/7za"
                 },
             },
             targets: targets,

--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -79,7 +79,7 @@ function getEmbeddedExodosPath(): string {
         return path.dirname(path.dirname(process.env.APPIMAGE));
     }
     if (process.platform === "darwin") {
-        return path.resolve(process.execPath, "../../../..");
+        return path.resolve(state.exePath, "../../../..");
     }
     return path.resolve(process.execPath, "../..");
 }


### PR DESCRIPTION
7za is already a universal binary, and the MacOS build pipeline was failing when lipo attempted to make it universal. This fixes.