### PR TITLE
fix: resolve extras directory path case-insensitively on macOS

### DIFF
--- a/src/renderer/redux/gamesMiddleware.ts
+++ b/src/renderer/redux/gamesMiddleware.ts
@@ -2,8 +2,8 @@ import { isAnyOf } from "@reduxjs/toolkit";
 import { readPlatformsFile } from "@renderer/file/PlatformFile";
 import { formatPlatformFileData } from "@renderer/util/LaunchBoxHelper";
 import { GameParser } from "@shared/game/GameParser";
+import { resolvePathSegmentCaseInsensitiveAsync } from "@shared/Util";
 import * as fs from "fs";
-import * as fsasync from "fs/promises";
 import * as path from "path";
 import { setGames, setLibraries } from "./gamesSlice";
 import {
@@ -102,15 +102,11 @@ async function loadPlatform(platform: string, platformsPath: string) {
 
     try {
         const findFileStart = Date.now();
-        const platformFileCaseInsensitive =
-            await findPlatformFileCaseInsensitive(
-                `${platform}.xml`,
-                platformsPath
-            );
-        const platformFile = path.join(
-            platformsPath,
-            platformFileCaseInsensitive
-        );
+        const resolvedFilename = await resolvePathSegmentCaseInsensitiveAsync(platformsPath, `${platform}.xml`);
+        if (!resolvedFilename) {
+            throw new Error(`Platform file ${platform}.xml doesn't exist in ${platformsPath} directory.`);
+        }
+        const platformFile = path.join(platformsPath, resolvedFilename);
         console.log(`[PERF] ${platform} - Find file: ${Date.now() - findFileStart}ms`);
 
         if ((await fs.promises.stat(platformFile)).isFile()) {
@@ -184,26 +180,6 @@ async function loadPlatform(platform: string, platformsPath: string) {
     return { games: [], addApps: [] } as IGameCollection;
 }
 
-// Of course there is a problem with casing in some platform files.
-// We need to list all of the files directory and search for the hits
-// manually.
-const findPlatformFileCaseInsensitive = async (
-    filename: string,
-    path: string
-): Promise<string> => {
-    console.debug(`Checking existence of platform ${filename} xml file..`);
-
-    const lowerCasedFilename = filename.toLowerCase();
-    const directoryContent = await fsasync.readdir(path);
-    const platformXmlFile = directoryContent.find(
-        (f) => f.toLowerCase() === lowerCasedFilename
-    );
-    if (!platformXmlFile)
-        throw new Error(
-            `Platform file ${filename} doesn't exist in ${path} directory.`
-        );
-    return platformXmlFile;
-};
 
 export type ErrorCopy = {
     columnNumber?: number;

--- a/src/renderer/util/addApps.ts
+++ b/src/renderer/util/addApps.ts
@@ -1,7 +1,7 @@
 import * as chokidar from "chokidar";
 import store from "@renderer/redux/store";
 import { updateGame } from "@renderer/redux/gamesSlice";
-import { deepCopy, fixSlashes } from "@shared/Util";
+import { deepCopy, fixSlashes, resolvePathSegmentCaseInsensitive } from "@shared/Util";
 import { IAdditionalApplicationInfo, IGameInfo } from "@shared/game/interfaces";
 import * as fs from "fs";
 import * as path from "path";
@@ -37,9 +37,18 @@ function loadAddAppsDirectory(game: IGameInfo, addAppsDir: string) {
         const addApps: IAdditionalApplicationInfo[] = [];
         const { rootFolder } = game;
 
+        const absoluteRootFolder = path.join(
+            window.External.config.fullExodosPath,
+            fixSlashes(rootFolder)
+        );
+        const resolvedDirName = resolvePathSegmentCaseInsensitive(absoluteRootFolder, addAppsDir);
+        if (!resolvedDirName) {
+            return [];
+        }
+
         const relativePathForAddApps = path.join(
             fixSlashes(rootFolder),
-            addAppsDir
+            resolvedDirName
         );
         const absolutePathForAddApps = path.join(
             window.External.config.fullExodosPath,

--- a/src/shared/Util.test.ts
+++ b/src/shared/Util.test.ts
@@ -1,0 +1,100 @@
+import * as fs from "fs";
+import {
+    resolvePathSegmentCaseInsensitive,
+    resolvePathSegmentCaseInsensitiveAsync,
+} from "./Util";
+
+jest.mock("fs", () => ({
+    readdirSync: jest.fn(),
+    promises: {
+        readdir: jest.fn(),
+    },
+}));
+
+const mockReaddirSync = fs.readdirSync as jest.Mock;
+const mockReaddirAsync = fs.promises.readdir as jest.Mock;
+
+describe("resolvePathSegmentCaseInsensitive", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns the entry with matching casing", () => {
+        mockReaddirSync.mockReturnValue(["Extras", "Magazines"]);
+        expect(resolvePathSegmentCaseInsensitive("/base", "Extras")).toBe("Extras");
+    });
+
+    it("returns the entry when segment casing differs from filesystem entry", () => {
+        mockReaddirSync.mockReturnValue(["extras", "magazines"]);
+        expect(resolvePathSegmentCaseInsensitive("/base", "Extras")).toBe("extras");
+    });
+
+    it("returns the entry when filesystem entry uses uppercase", () => {
+        mockReaddirSync.mockReturnValue(["EXTRAS"]);
+        expect(resolvePathSegmentCaseInsensitive("/base", "Extras")).toBe("EXTRAS");
+    });
+
+    it("returns undefined when no matching entry exists", () => {
+        mockReaddirSync.mockReturnValue(["Manuals", "Music"]);
+        expect(resolvePathSegmentCaseInsensitive("/base", "Extras")).toBeUndefined();
+    });
+
+    it("returns undefined when directory does not exist", () => {
+        mockReaddirSync.mockImplementation(() => {
+            const err = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+            err.code = "ENOENT";
+            throw err;
+        });
+        expect(resolvePathSegmentCaseInsensitive("/nonexistent", "Extras")).toBeUndefined();
+    });
+
+    it("returns undefined when directory read fails with other error", () => {
+        mockReaddirSync.mockImplementation(() => {
+            throw new Error("EPERM: permission denied");
+        });
+        expect(resolvePathSegmentCaseInsensitive("/protected", "Extras")).toBeUndefined();
+    });
+
+    it("returns the first match when multiple entries match case-insensitively", () => {
+        mockReaddirSync.mockReturnValue(["extras", "Extras"]);
+        expect(resolvePathSegmentCaseInsensitive("/base", "Extras")).toBe("extras");
+    });
+});
+
+describe("resolvePathSegmentCaseInsensitiveAsync", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns the entry with matching casing", async () => {
+        mockReaddirAsync.mockResolvedValue(["Extras", "Magazines"]);
+        await expect(resolvePathSegmentCaseInsensitiveAsync("/base", "Extras")).resolves.toBe("Extras");
+    });
+
+    it("returns the entry when segment casing differs from filesystem entry", async () => {
+        mockReaddirAsync.mockResolvedValue(["extras", "magazines"]);
+        await expect(resolvePathSegmentCaseInsensitiveAsync("/base", "Extras")).resolves.toBe("extras");
+    });
+
+    it("returns the entry when filesystem entry uses uppercase", async () => {
+        mockReaddirAsync.mockResolvedValue(["EXTRAS"]);
+        await expect(resolvePathSegmentCaseInsensitiveAsync("/base", "Extras")).resolves.toBe("EXTRAS");
+    });
+
+    it("returns undefined when no matching entry exists", async () => {
+        mockReaddirAsync.mockResolvedValue(["Manuals", "Music"]);
+        await expect(resolvePathSegmentCaseInsensitiveAsync("/base", "Extras")).resolves.toBeUndefined();
+    });
+
+    it("returns undefined when directory does not exist", async () => {
+        const err = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        mockReaddirAsync.mockRejectedValue(err);
+        await expect(resolvePathSegmentCaseInsensitiveAsync("/nonexistent", "Extras")).resolves.toBeUndefined();
+    });
+
+    it("returns undefined when directory read fails with other error", async () => {
+        mockReaddirAsync.mockRejectedValue(new Error("EPERM: permission denied"));
+        await expect(resolvePathSegmentCaseInsensitiveAsync("/protected", "Extras")).resolves.toBeUndefined();
+    });
+});

--- a/src/shared/Util.ts
+++ b/src/shared/Util.ts
@@ -527,6 +527,30 @@ export function preparePathForShell(filePath: string, options?: { quote?: boolea
     }
 }
 
+export function resolvePathSegmentCaseInsensitive(
+    parentAbsPath: string,
+    segment: string
+): string | undefined {
+    try {
+        const entries = fs.readdirSync(parentAbsPath);
+        return entries.find((e) => e.toLowerCase() === segment.toLowerCase());
+    } catch {
+        return undefined;
+    }
+}
+
+export async function resolvePathSegmentCaseInsensitiveAsync(
+    parentAbsPath: string,
+    segment: string
+): Promise<string | undefined> {
+    try {
+        const entries = await fs.promises.readdir(parentAbsPath);
+        return entries.find((e) => e.toLowerCase() === segment.toLowerCase());
+    } catch {
+        return undefined;
+    }
+}
+
 export function removeLowestDirectory(filePath: string, popCount = 1): string {
     const normalizedPath = path.normalize(filePath).replace(/\\/g, "/");
     const pathSegments = normalizedPath.split("/");


### PR DESCRIPTION
Extras and Magazines directories were not found on macOS due to case-sensitive filesystem treating e.g. "extras" and "Extras" as different paths. Extract shared resolvePathSegmentCaseInsensitive(Async) helpers into Util.ts and use them in addApps.ts (extras loading) and gamesMiddleware.ts (platform XML loading).