### PR TITLE
feat: add keyboard quick-search jump in grid and list views

### DIFF
--- a/src/renderer/components/pages/BrowsePage.test.ts
+++ b/src/renderer/components/pages/BrowsePage.test.ts
@@ -1,0 +1,104 @@
+import { IGameInfo } from "@shared/game/interfaces";
+import { binarySearchGame, linearSearchGame } from "../../util/quickSearch";
+
+const g = (orderTitle: string, id = orderTitle): IGameInfo =>
+    ({
+        id,
+        orderTitle,
+    } as IGameInfo);
+
+// Sorted alphabetically by orderTitle (as searchMiddleware produces for title-ascending order)
+const sortedGames: IGameInfo[] = [
+    g("aladdin"),
+    g("doom"),
+    g("prince of persia"),
+    g("supaplex"),
+    g("super mario bros"),
+    g("super noah's ark 3d"),
+    g("ultima iv"),
+    g("wolfenstein 3d"),
+];
+
+// Same games in a non-alphabetical order (simulating e.g. year or developer sort)
+const unsortedGames: IGameInfo[] = [
+    g("wolfenstein 3d"),
+    g("super noah's ark 3d"),
+    g("doom"),
+    g("supaplex"),
+    g("aladdin"),
+    g("super mario bros"),
+    g("prince of persia"),
+    g("ultima iv"),
+];
+
+describe("binarySearchGame", () => {
+    test("finds exact title match", () => {
+        expect(binarySearchGame(sortedGames, "doom")?.orderTitle).toBe("doom");
+    });
+
+    test("finds first game with matching prefix", () => {
+        expect(binarySearchGame(sortedGames, "sup")?.orderTitle).toBe("supaplex");
+    });
+
+    test("distinguishes supaplex from super titles", () => {
+        expect(binarySearchGame(sortedGames, "supa")?.orderTitle).toBe("supaplex");
+        expect(binarySearchGame(sortedGames, "supe")?.orderTitle).toBe("super mario bros");
+    });
+
+    test("finds first alphabetically when multiple games share a prefix", () => {
+        expect(binarySearchGame(sortedGames, "super")?.orderTitle).toBe("super mario bros");
+    });
+
+    test("returns first game when query matches beginning of list", () => {
+        expect(binarySearchGame(sortedGames, "a")?.orderTitle).toBe("aladdin");
+    });
+
+    test("returns last game when query matches last entry", () => {
+        expect(binarySearchGame(sortedGames, "wolf")?.orderTitle).toBe("wolfenstein 3d");
+    });
+
+    test("returns nearest game when no prefix match exists", () => {
+        // "zzz" is past everything — no result
+        expect(binarySearchGame(sortedGames, "zzz")).toBeUndefined();
+    });
+
+    test("returns undefined for empty list", () => {
+        expect(binarySearchGame([], "doom")).toBeUndefined();
+    });
+
+    test("query is case-insensitive (orderTitle is already lowercase)", () => {
+        expect(binarySearchGame(sortedGames, "doom")?.orderTitle).toBe("doom");
+    });
+});
+
+describe("linearSearchGame", () => {
+    test("finds exact title match regardless of display order", () => {
+        expect(linearSearchGame(unsortedGames, "doom")?.orderTitle).toBe("doom");
+    });
+
+    test("finds supaplex even though super titles appear earlier in display order", () => {
+        expect(linearSearchGame(unsortedGames, "supa")?.orderTitle).toBe("supaplex");
+    });
+
+    test("returns alphabetically first match among all prefix matches", () => {
+        // Both "super mario bros" and "super noah's ark 3d" start with "super";
+        // "super mario bros" < "super noah's ark 3d" alphabetically
+        expect(linearSearchGame(unsortedGames, "super")?.orderTitle).toBe("super mario bros");
+    });
+
+    test("finds single-character prefix — alphabetically first match", () => {
+        expect(linearSearchGame(unsortedGames, "s")?.orderTitle).toBe("supaplex");
+    });
+
+    test("returns undefined when no game matches prefix", () => {
+        expect(linearSearchGame(unsortedGames, "xyz")).toBeUndefined();
+    });
+
+    test("returns undefined for empty list", () => {
+        expect(linearSearchGame([], "doom")).toBeUndefined();
+    });
+
+    test("handles multi-word prefix", () => {
+        expect(linearSearchGame(unsortedGames, "prince of")?.orderTitle).toBe("prince of persia");
+    });
+});

--- a/src/renderer/components/pages/BrowsePage.tsx
+++ b/src/renderer/components/pages/BrowsePage.tsx
@@ -25,6 +25,7 @@ import {
     withPreferences,
 } from "../../containers/withPreferences";
 import { gameScaleSpan, openContextMenu } from "../../Util";
+import { binarySearchGame, linearSearchGame } from "../../util/quickSearch";
 import { GameGridWithWrapping } from "../GameGridWithWrapping";
 import { GameList } from "../GameList";
 import { GameOrderChangeEvent } from "../GameOrder";
@@ -94,7 +95,7 @@ class BrowsePage extends React.Component<
     boundSetState = this.setState.bind(this);
 
     /** Time it takes before the current "quick search" string to reset after a change was made (in milliseconds). */
-    static readonly quickSearchTimeout: number = 1500;
+    static readonly quickSearchTimeout: number = 1000;
 
     constructor(props: ConnectedBrowsePageProps) {
         super(props);
@@ -122,7 +123,7 @@ class BrowsePage extends React.Component<
         });
     }
 
-    componentDidUpdate(prevProps: ConnectedBrowsePageProps) {
+    componentDidUpdate(prevProps: ConnectedBrowsePageProps, prevState: BrowsePageState) {
         const prevView = prevProps.searchState.views[prevProps.gameLibrary];
         const currentView = this.props.searchState.views[this.props.gameLibrary];
 
@@ -152,6 +153,19 @@ class BrowsePage extends React.Component<
             updatePreferencesData({
                 browsePageShowLeftSidebar: !!this.props.playlists.length,
             });
+        }
+
+        if (this.state.quickSearch !== prevState.quickSearch && this.state.quickSearch) {
+            const view = this.props.searchState.views[this.props.gameLibrary];
+            if (view && view.games.length > 0) {
+                const isTitleAscending = view.orderBy === "title" && view.orderReverse === "ascending";
+                const game = isTitleAscending
+                    ? binarySearchGame(view.games, this.state.quickSearch)
+                    : linearSearchGame(view.games, this.state.quickSearch);
+                if (game) {
+                    this.onGameSelect(game);
+                }
+            }
         }
     }
 
@@ -432,9 +446,12 @@ class BrowsePage extends React.Component<
             } else if (key.length === 1) {
                 // (Single character - add it to the search string)
                 const timedOut = updateTime.call(this);
-                const newString: string =
-                    (timedOut ? "" : this.state.quickSearch) + key;
-                this.setState({ quickSearch: newString });
+                const currentSearch = timedOut ? "" : this.state.quickSearch;
+                if (key === " " && !currentSearch) {
+                    return;
+                }
+                event.preventDefault();
+                this.setState({ quickSearch: currentSearch + key });
             }
         }
 
@@ -555,6 +572,7 @@ class BrowsePage extends React.Component<
 }
 
 export default withPreferences(connector(BrowsePage));
+
 
 function calcScale(defHeight: number, scale: number): number {
     return (defHeight + (scale - 0.5) * 2 * defHeight * gameScaleSpan) | 0;

--- a/src/renderer/util/quickSearch.ts
+++ b/src/renderer/util/quickSearch.ts
@@ -1,0 +1,29 @@
+import { IGameInfo } from "@shared/game/interfaces";
+
+export function binarySearchGame(games: IGameInfo[], query: string): IGameInfo | undefined {
+    const q = query.toLowerCase();
+    let lo = 0;
+    let hi = games.length - 1;
+    let result: IGameInfo | undefined;
+    while (lo <= hi) {
+        const mid = (lo + hi) >>> 1;
+        if (games[mid].orderTitle >= q) {
+            result = games[mid];
+            hi = mid - 1;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    return result;
+}
+
+export function linearSearchGame(games: IGameInfo[], query: string): IGameInfo | undefined {
+    const q = query.toLowerCase();
+    let best: IGameInfo | undefined;
+    for (const g of games) {
+        if (g.orderTitle.startsWith(q) && (!best || g.orderTitle < best.orderTitle)) {
+            best = g;
+        }
+    }
+    return best;
+}


### PR DESCRIPTION
- Typing letters while browsing jumps to the first matching game by orderTitle
- Binary search used when sorted by title ascending; linear search otherwise
- Space included in quick search once a search is in progress
- Timeout reset to 1000ms