### PR TITLE
revert: drop CI macOS ad-hoc signing attempt

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -116,12 +116,6 @@ jobs:
 
       - name: Build ${{ matrix.name }}
         run: npm run ${{ matrix.script }}
-        env:
-          # Release runs in a pull_request (merged) context, where electron-builder
-          # skips ALL macOS signing — including the ad-hoc fallback the universal
-          # build needs to launch on Apple Silicon. Setting this re-enables signing
-          # so the "identity: -" ad-hoc signature is applied. (Ignored on Linux/Windows.)
-          CSC_FOR_PULL_REQUEST: "true"
 
       - name: Generate beta channel yml files
         shell: bash
@@ -165,10 +159,6 @@ jobs:
 
       - name: Build macOS (Legacy)
         run: npm run release:mac-universal
-        env:
-          # See note above: re-enable signing in pull_request context so the
-          # ad-hoc signature is applied to the legacy macOS build too.
-          CSC_FOR_PULL_REQUEST: "true"
 
       - name: Rename artifacts to legacy
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,12 +116,6 @@ jobs:
 
       - name: Build ${{ matrix.name }}
         run: npm run ${{ matrix.script }}
-        env:
-          # Release runs in a pull_request (merged) context, where electron-builder
-          # skips ALL macOS signing — including the ad-hoc fallback the universal
-          # build needs to launch on Apple Silicon. Setting this re-enables signing
-          # so the "identity: -" ad-hoc signature is applied. (Ignored on Linux/Windows.)
-          CSC_FOR_PULL_REQUEST: "true"
 
       - name: List dist directory
         shell: bash
@@ -158,10 +152,6 @@ jobs:
 
       - name: Build macOS (Legacy)
         run: npm run release:mac-universal
-        env:
-          # See note above: re-enable signing in pull_request context so the
-          # ad-hoc signature is applied to the legacy macOS build too.
-          CSC_FOR_PULL_REQUEST: "true"
 
       - name: Rename artifacts to legacy
         shell: bash

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 The launcher for Retro eXo Projects.
 
-> 🍎 **macOS users:** exogui binaries are **not signed with an Apple Developer ID and are not notarized.** macOS will block downloaded builds ("exogui is damaged and can't be opened") until you clear the quarantine attribute:
+> 🍎 **macOS users:** exogui binaries are **not code signed and not notarized.** macOS blocks downloaded builds ("exogui is damaged and can't be opened"), and on Apple Silicon the app won't launch until it is locally (ad-hoc) signed. After moving the app into place, run:
 >
 > ```bash
-> xattr -cr /Applications/exogui.app && open /Applications/exogui.app
+> xattr -cr /Applications/exogui.app
+> codesign --force --deep --sign - /Applications/exogui.app
+> open /Applications/exogui.app
 > ```
 >
-> This one-time step is unavoidable without a paid Apple Developer account. See [Troubleshooting](docs/troubleshooting.md#exogui-is-damaged-and-cant-be-opened--app-wont-launch-after-download) for details.
+> These one-time steps are unavoidable without a paid Apple Developer account. See [Troubleshooting](docs/troubleshooting.md#exogui-is-damaged-and-cant-be-opened--app-wont-launch-after-download) for details.
 
 ## Links
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -196,27 +196,31 @@ Check the [exogui discord](https://discord.gg/yMcZnyUn) for the latest macOS dev
 *"exogui is damaged and can't be opened. You should move it to the Trash"*, or the app
 silently fails to launch.
 
-**Cause:** exogui is **ad-hoc signed**, not signed with a paid Apple Developer ID, and it is
-**not notarized**. When you download a file, macOS tags it with a quarantine attribute
-(`com.apple.quarantine`). Gatekeeper refuses to launch a quarantined app that lacks a
-Developer ID signature + notarization, regardless of how the app itself is built. This is a
-macOS policy, not a problem with the download — the `.dmg` and `.zip` contain an identical,
-intact app.
+**Cause:** exogui binaries are **not code signed and not notarized** (this requires a paid
+Apple Developer account). Two macOS protections kick in:
 
-**Solution:** Remove the quarantine attribute, then open the app:
+1. When you download a file, macOS tags it with a quarantine attribute
+   (`com.apple.quarantine`), and Gatekeeper blocks launching an unsigned, quarantined app.
+2. On Apple Silicon, the kernel refuses to run code that has no signature at all — so the
+   app must be locally (ad-hoc) signed before it will launch.
+
+This is a macOS policy, not a problem with the download — the `.dmg` and `.zip` contain an
+identical, intact app.
+
+**Solution:** Clear the quarantine attribute, ad-hoc sign the app locally, then open it:
 
 ```bash
 # Adjust the path to wherever you placed exogui.app (e.g. /Applications)
 xattr -cr /Applications/exogui.app
+codesign --force --deep --sign - /Applications/exogui.app
 open /Applications/exogui.app
 ```
 
-`xattr -cr` clears the quarantine attribute recursively. After this, the ad-hoc signature is
-accepted and the app launches normally.
+`xattr -cr` clears the quarantine attribute recursively, and `codesign --sign -` applies a
+free local ad-hoc signature so the app is allowed to run. After this it launches normally.
 
-> **Note:** This manual step is unavoidable without a paid Apple Developer account.
-> Proper Developer ID signing + notarization would let the app open with no extra steps,
-> but ad-hoc signing (which is free) cannot satisfy Gatekeeper for downloaded files.
+> **Note:** These manual steps are unavoidable without a paid Apple Developer account.
+> Proper Developer ID signing + notarization would let the app open with no extra steps.
 
 ---
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,11 +117,7 @@ gulp.task("pack", (done) => {
                 },
                 mac: {
                     icon: "./icons/icon.icns",
-                    x64ArchFiles: "**/7za",
-                    // Ad-hoc sign ("-"): no Apple Developer cert needed. Required so
-                    // the universal/arm64 build is runnable on Apple Silicon at all.
-                    // Does NOT satisfy Gatekeeper for downloads (see docs/troubleshooting.md).
-                    identity: "-",
+                    x64ArchFiles: "**/7za"
                 },
             },
             targets: targets,


### PR DESCRIPTION
electron-builder's signing fails because extraFiles place loose files (mappings.*.json, lang, licenses) in the app's Contents/, which breaks the code-signing seal ("code object is not signed at all. In subcomponent: .../mappings.win32.json"). Fixing that means relocating those files and updating runtime paths across all platforms — too risky for the benefit.

Revert to shipping unsigned binaries and signing on the client:
- gulpfile: remove mac.identity "-"
- workflows: remove CSC_FOR_PULL_REQUEST env from build steps
- docs: update README + troubleshooting to reflect unsigned binaries (client must run xattr -cr + codesign --sign -)