### PR TITLE
feat: show only playlists belonging to the selected platform

### DIFF
--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -248,6 +248,11 @@ async function initializePlaylistManager() {
         state.config.exodosPath,
         state.config.playlistFolderPath
     );
+    const parentsFilePath = path.join(
+        state.config.exodosPath,
+        state.config.jsonFolderPath,
+        "Parents.xml"
+    );
 
     const onPlaylistAddOrUpdate = function (playlist: GamePlaylist): void {
         // Clear all query caches that uses this playlist
@@ -267,6 +272,7 @@ async function initializePlaylistManager() {
 
     await state.playlistManager.init({
         playlistFolder,
+        parentsFilePath,
         log,
         onPlaylistAddOrUpdate,
     });

--- a/src/back/playlist/ParentsFile.test.ts
+++ b/src/back/playlist/ParentsFile.test.ts
@@ -1,0 +1,83 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { ParentsFile } from "./ParentsFile";
+
+async function writeTempXml(content: string): Promise<string> {
+    const filePath = path.join(
+        os.tmpdir(),
+        `parents-test-${Date.now()}-${Math.random()}.xml`
+    );
+    await fs.promises.writeFile(filePath, content, "utf8");
+    return filePath;
+}
+
+describe("ParentsFile.readPlaylistPlatformMap", () => {
+    it("maps playlist ids to their parent platform name", async () => {
+        const filePath = await writeTempXml(`<?xml version="1.0"?>
+<LaunchBox>
+  <Parent>
+    <PlaylistId>id-1</PlaylistId>
+    <ParentPlatformName>MS-DOS</ParentPlatformName>
+  </Parent>
+  <Parent>
+    <PlaylistId>id-2</PlaylistId>
+    <ParentPlatformName>DREAMM</ParentPlatformName>
+  </Parent>
+</LaunchBox>`);
+        const map = await ParentsFile.readPlaylistPlatformMap(filePath);
+        await fs.promises.unlink(filePath);
+
+        expect(map.get("id-1")).toBe("MS-DOS");
+        expect(map.get("id-2")).toBe("DREAMM");
+        expect(map.size).toBe(2);
+    });
+
+    it("ignores entries without both a playlist id and a parent platform", async () => {
+        const filePath = await writeTempXml(`<?xml version="1.0"?>
+<LaunchBox>
+  <Parent>
+    <PlatformName>MS-DOS</PlatformName>
+    <ParentPlatformCategoryName>Computers</ParentPlatformCategoryName>
+  </Parent>
+  <Parent>
+    <PlaylistId />
+    <ParentPlatformName>MS-DOS</ParentPlatformName>
+  </Parent>
+  <Parent>
+    <PlaylistId>id-1</PlaylistId>
+    <ParentPlatformName />
+  </Parent>
+  <Parent>
+    <PlaylistId>id-2</PlaylistId>
+    <ParentPlatformName>MS-DOS</ParentPlatformName>
+  </Parent>
+</LaunchBox>`);
+        const map = await ParentsFile.readPlaylistPlatformMap(filePath);
+        await fs.promises.unlink(filePath);
+
+        expect(map.size).toBe(1);
+        expect(map.get("id-2")).toBe("MS-DOS");
+    });
+
+    it("fixes the encoded ampersand in platform names", async () => {
+        const filePath = await writeTempXml(`<?xml version="1.0"?>
+<LaunchBox>
+  <Parent>
+    <PlaylistId>id-1</PlaylistId>
+    <ParentPlatformName>Magazines &amp;amp; Newsletters</ParentPlatformName>
+  </Parent>
+</LaunchBox>`);
+        const map = await ParentsFile.readPlaylistPlatformMap(filePath);
+        await fs.promises.unlink(filePath);
+
+        expect(map.get("id-1")).toBe("Magazines & Newsletters");
+    });
+
+    it("returns an empty map when the file does not exist", async () => {
+        const map = await ParentsFile.readPlaylistPlatformMap(
+            path.join(os.tmpdir(), "does-not-exist-parents.xml")
+        );
+        expect(map.size).toBe(0);
+    });
+});

--- a/src/back/playlist/ParentsFile.ts
+++ b/src/back/playlist/ParentsFile.ts
@@ -1,0 +1,53 @@
+import { XMLParser } from "fast-xml-parser";
+import * as fs from "fs";
+
+export namespace ParentsFile {
+    /**
+     * Read Parents.xml and build a map of playlist id to the platform (library)
+     * the playlist belongs to.
+     * @param filePath Path of the Parents.xml file.
+     */
+    export async function readPlaylistPlatformMap(
+        filePath: string
+    ): Promise<Map<string, string>> {
+        let data: Buffer;
+        try {
+            data = await fs.promises.readFile(filePath);
+        } catch {
+            return new Map();
+        }
+
+        let parsed: any;
+        try {
+            const parser = new XMLParser();
+            parsed = parser.parse(data.toString());
+        } catch {
+            return new Map();
+        }
+
+        return parsePlaylistPlatformMap(parsed.LaunchBox || {});
+    }
+
+    function parsePlaylistPlatformMap(data: any): Map<string, string> {
+        const parentsRaw = data.Parent
+            ? Array.isArray(data.Parent)
+                ? data.Parent
+                : [data.Parent]
+            : [];
+
+        const map = new Map<string, string>();
+        for (const parent of parentsRaw) {
+            const playlistId = normalize(parent.PlaylistId);
+            const platform = normalize(parent.ParentPlatformName);
+            if (playlistId && platform) {
+                // Fix for platforms which have incorrect encoding of the ampersand character
+                map.set(playlistId, platform.replace("&amp;", "&"));
+            }
+        }
+        return map;
+    }
+
+    function normalize(value: unknown): string {
+        return typeof value === "string" ? value.trim() : "";
+    }
+}

--- a/src/back/playlist/PlaylistFile.test.ts
+++ b/src/back/playlist/PlaylistFile.test.ts
@@ -1,0 +1,44 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { PlaylistFile } from "./PlaylistFile";
+
+async function writeTempXml(content: string): Promise<string> {
+    const filePath = path.join(
+        os.tmpdir(),
+        `playlist-test-${Date.now()}-${Math.random()}.xml`
+    );
+    await fs.promises.writeFile(filePath, content, "utf8");
+    return filePath;
+}
+
+describe("PlaylistFile.readFile", () => {
+    it("extracts the playlist id", async () => {
+        const filePath = await writeTempXml(`<?xml version="1.0"?>
+<LaunchBox>
+  <Playlist>
+    <PlaylistId>abc-123</PlaylistId>
+    <Name>My Playlist</Name>
+    <Notes>Some notes</Notes>
+  </Playlist>
+</LaunchBox>`);
+        const playlist = await PlaylistFile.readFile(filePath);
+        await fs.promises.unlink(filePath);
+
+        expect(playlist.playlistId).toBe("abc-123");
+        expect(playlist.title).toBe("My Playlist");
+    });
+
+    it("defaults the playlist id to an empty string when missing", async () => {
+        const filePath = await writeTempXml(`<?xml version="1.0"?>
+<LaunchBox>
+  <Playlist>
+    <Name>No Id Playlist</Name>
+  </Playlist>
+</LaunchBox>`);
+        const playlist = await PlaylistFile.readFile(filePath);
+        await fs.promises.unlink(filePath);
+
+        expect(playlist.playlistId).toBe("");
+    });
+});

--- a/src/back/playlist/PlaylistFile.ts
+++ b/src/back/playlist/PlaylistFile.ts
@@ -40,6 +40,7 @@ export namespace PlaylistFile {
         onError?: (error: string) => void
     ): GamePlaylistContent {
         const playlist: GamePlaylistContent = {
+            playlistId: "",
             games: [],
             title: "",
             description: "",
@@ -59,6 +60,7 @@ export namespace PlaylistFile {
                 : [data.PlaylistFilter]
             : [];
         const intermediatePlaylistFormat = {
+            playlistId: playlistInfo.PlaylistId,
             title: playlistInfo.Name,
             description: playlistInfo.Notes,
             author: "",
@@ -89,6 +91,7 @@ export namespace PlaylistFile {
                         `Error while converting Playlist: ${e.toString()}`
                     )),
         });
+        parser.prop("playlistId", (v) => (playlist.playlistId = str(v)), true);
         parser.prop("title", (v) => (playlist.title = str(v)));
         parser.prop("description", (v) => (playlist.description = str(v)));
         parser.prop("author", (v) => (playlist.author = str(v)));

--- a/src/back/playlist/PlaylistManager.ts
+++ b/src/back/playlist/PlaylistManager.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 
+import { ParentsFile } from "./ParentsFile";
 import { PlaylistFile } from "./PlaylistFile";
 import { LogFunc } from "@back/types";
 import { GamePlaylist } from "@shared/interfaces";
@@ -8,12 +9,14 @@ import { GamePlaylist } from "@shared/interfaces";
 export type PlaylistUpdatedFunc = (playlist: GamePlaylist) => void;
 export interface PlaylistManagerOpts {
     playlistFolder: string;
+    parentsFilePath: string;
     log: LogFunc;
     onPlaylistAddOrUpdate: PlaylistUpdatedFunc;
 }
 
 export class PlaylistManager {
     private _initialized = false;
+    private _playlistPlatformMap: Map<string, string> = new Map();
 
     public readonly playlists: GamePlaylist[] = [];
 
@@ -25,6 +28,8 @@ export class PlaylistManager {
 
         console.log("Loading playlists...");
         try {
+            this._playlistPlatformMap =
+                await ParentsFile.readPlaylistPlatformMap(opts.parentsFilePath);
             const playlistFiles = (
                 await fs.promises.readdir(opts.playlistFolder, {
                     withFileTypes: true,
@@ -69,6 +74,7 @@ export class PlaylistManager {
             playlist = {
                 ...data,
                 filename,
+                library: this._playlistPlatformMap.get(data.playlistId),
             };
         } catch (error) {
             opts.log({

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -401,7 +401,8 @@ class App extends React.Component<AppProps, AppState> {
             this.props.libraries[0] ??
             "";
         const playlists = this.orderAndFilterPlaylistsMemo(
-            this.state.playlists
+            this.state.playlists,
+            libraryPath
         );
 
         // Props to set to the router
@@ -581,17 +582,21 @@ class App extends React.Component<AppProps, AppState> {
         });
     }
 
-    orderAndFilterPlaylistsMemo = memoizeOne((playlists: GamePlaylist[]) => {
-        return [...playlists].sort((a, b) => {
-            if (a.title < b.title) {
-                return -1;
-            }
-            if (a.title > b.title) {
-                return 1;
-            }
-            return 0;
-        });
-    });
+    orderAndFilterPlaylistsMemo = memoizeOne(
+        (playlists: GamePlaylist[], libraryPath: string) => {
+            return [...playlists]
+            .filter((p) => !p.library || p.library === libraryPath)
+            .sort((a, b) => {
+                if (a.title < b.title) {
+                    return -1;
+                }
+                if (a.title > b.title) {
+                    return 1;
+                }
+                return 0;
+            });
+        }
+    );
 
     private unmountBeforeClose = (): void => {
         this.setState({ stopRender: true });

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -214,10 +214,14 @@ export type IBackProcessInfo = {
 export type GamePlaylist = GamePlaylistContent & {
     /** Filename of the playlist (unique for each playlist). */
     filename: string;
+    /** Name of the platform (library) this playlist belongs to, if any (from Parents.xml). */
+    library?: string;
 };
 
 /** Data contained inside a Playlist file. */
 export type GamePlaylistContent = {
+    /** Unique id of the playlist (used to associate it with a platform via Parents.xml). */
+    playlistId: string;
     /** Game entries in the playlist. */
     games: GamePlaylistEntry[];
     /** Title of the playlist. */

--- a/src/shared/utils/ObjectParser.ts
+++ b/src/shared/utils/ObjectParser.ts
@@ -308,7 +308,7 @@ function createStack(
     label: string | number | symbol
 ): string[] {
     const newStack = stack.slice();
-    newStack.push(label + "");
+    newStack.push(String(label));
     return newStack;
 }
 


### PR DESCRIPTION
Read Data/Parents.xml to map each playlist (by PlaylistId) to its parent platform and filter the playlist sidebar by the current library. Playlists with no platform association (or when Parents.xml is absent) remain visible on every platform.

Also fix a latent symbol-key crash in ObjectParser stack handling.