### PR TITLE
feat: filter games by clicking metadata fields in the right sidebar

### DIFF
--- a/src/renderer/components/RightBrowseSidebar.tsx
+++ b/src/renderer/components/RightBrowseSidebar.tsx
@@ -2,6 +2,7 @@ import { shell } from "@electron/remote";
 import { faFolder, faHeart } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { englishTranslation } from "@renderer/lang/en";
+import { AdvancedFilter } from "@renderer/redux/searchSlice";
 import { loadDynamicAddAppsForGame } from "@renderer/util/addApps";
 import { openGameConfigDirectory } from "@renderer/util/games";
 import { fixSlashes } from "@shared/Util";
@@ -14,7 +15,6 @@ import * as path from "path";
 import * as React from "react";
 import { getGameImagePath, openContextMenu } from "../Util";
 import { WithPreferencesProps } from "../containers/withPreferences";
-import { DropdownInputField } from "./DropdownInputField";
 import { FormattedGameMedia, GameImageCarousel } from "./GameImageCarousel";
 import { MediaPreview } from "./ImagePreview";
 import { InputField } from "./InputField";
@@ -37,6 +37,8 @@ type OwnProps = {
     onAddAppLaunch: (addApp: IAdditionalApplicationInfo) => void;
     /** Toggle favorite state for the current game */
     onFavoriteToggle: (game: IGameInfo) => void;
+    /** Apply a metadata field value as an advanced filter in the current view */
+    onSearchField: (field: keyof AdvancedFilter, value: string) => void;
 };
 
 export type RightBrowseSidebarProps = OwnProps & WithPreferencesProps;
@@ -95,6 +97,16 @@ export class RightBrowseSidebar extends React.Component<
         );
 
         this.setState({ dynamicAddApps });
+    };
+
+    wrapOnFieldClick = (
+        field: keyof AdvancedFilter,
+        value: string
+    ): (() => void) | undefined => {
+        if (!value) {
+            return undefined;
+        }
+        return () => this.props.onSearchField(field, value);
     };
 
     componentDidMount(): void {
@@ -209,15 +221,14 @@ export class RightBrowseSidebar extends React.Component<
                     <div className="browse-right-sidebar__section">
                         <div className="browse-right-sidebar__row browse-right-sidebar__row--one-line">
                             <p>{strings.tags}: </p>
-                            <DropdownInputField
+                            <InputField
                                 text={game.genre}
                                 placeholder={strings.noTags}
                                 className="browse-right-sidebar__searchable"
-                                items={[]}
-                                onItemSelect={(text) => {
-                                    game.genre = text;
-                                    this.forceUpdate();
-                                }}
+                                onClick={this.wrapOnFieldClick(
+                                    "genre",
+                                    game.genre
+                                )}
                             />
                         </div>
                         <div className="browse-right-sidebar__row browse-right-sidebar__row--one-line">
@@ -226,6 +237,10 @@ export class RightBrowseSidebar extends React.Component<
                                 text={game.series}
                                 placeholder={strings.noSeries}
                                 className="browse-right-sidebar__searchable"
+                                onClick={this.wrapOnFieldClick(
+                                    "series",
+                                    game.series
+                                )}
                             />
                         </div>
                         <div className="browse-right-sidebar__row browse-right-sidebar__row--one-line">
@@ -234,6 +249,10 @@ export class RightBrowseSidebar extends React.Component<
                                 text={game.developer}
                                 placeholder={strings.noDeveloper}
                                 className="browse-right-sidebar__searchable"
+                                onClick={this.wrapOnFieldClick(
+                                    "developer",
+                                    game.developer
+                                )}
                             />
                         </div>
                         <div className="browse-right-sidebar__row browse-right-sidebar__row--one-line">
@@ -242,6 +261,10 @@ export class RightBrowseSidebar extends React.Component<
                                 text={game.publisher}
                                 placeholder={strings.noPublisher}
                                 className="browse-right-sidebar__searchable"
+                                onClick={this.wrapOnFieldClick(
+                                    "publisher",
+                                    game.publisher
+                                )}
                             />
                         </div>
                         <div className="browse-right-sidebar__row browse-right-sidebar__row--one-line">
@@ -249,33 +272,25 @@ export class RightBrowseSidebar extends React.Component<
                             <InputField
                                 text={game.source}
                                 placeholder={strings.noSource}
-                                className="browse-right-sidebar__searchable"
                             />
                         </div>
                         <div className="browse-right-sidebar__row browse-right-sidebar__row--one-line">
                             <p>{strings.platform}: </p>
-                            <DropdownInputField
+                            <InputField
                                 text={game.platform}
                                 placeholder={strings.noPlatform}
-                                className="browse-right-sidebar__searchable"
-                                items={[]}
-                                onItemSelect={(text) => {
-                                    game.platform = text;
-                                    this.forceUpdate();
-                                }}
                             />
                         </div>
                         <div className="browse-right-sidebar__row browse-right-sidebar__row--one-line">
                             <p>{strings.playMode}: </p>
-                            <DropdownInputField
+                            <InputField
                                 text={game.playMode}
                                 placeholder={strings.noPlayMode}
                                 className="browse-right-sidebar__searchable"
-                                items={[]}
-                                onItemSelect={(text) => {
-                                    game.playMode = text;
-                                    this.forceUpdate();
-                                }}
+                                onClick={this.wrapOnFieldClick(
+                                    "playMode",
+                                    game.playMode
+                                )}
                             />
                         </div>
                         <div className="browse-right-sidebar__row browse-right-sidebar__row--one-line">
@@ -286,6 +301,10 @@ export class RightBrowseSidebar extends React.Component<
                                 .toString()}
                                 placeholder={strings.noReleaseDate}
                                 className="browse-right-sidebar__searchable"
+                                onClick={this.wrapOnFieldClick(
+                                    "releaseYear",
+                                    game.releaseYear
+                                )}
                             />
                         </div>
                     </div>

--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -6,6 +6,7 @@ import {
     setSearchText,
 } from "@renderer/redux/searchSlice";
 import { RootState } from "@renderer/redux/store";
+import { PreferencesContext } from "../context/PreferencesContext";
 import { updatePreferencesData } from "@shared/preferences/util";
 import { faCheck, faFilter, faFilterCircleXmark, faHeart, faLaptop, faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -29,14 +30,11 @@ export type SearchBarProps = {
 export function SearchBar(props: SearchBarProps) {
     const { searchState } = useSelector((state: RootState) => state);
     const dispatch = useDispatch();
-    const [expanded, setExpanded] = React.useState(
-        window.External.preferences.data.browsePageFiltersExpanded
-    );
+    const preferences = React.useContext(PreferencesContext);
+    const expanded = preferences.browsePageFiltersExpanded;
 
     const onToggleExpanded = () => {
-        const next = !expanded;
-        setExpanded(next);
-        updatePreferencesData({ browsePageFiltersExpanded: next });
+        updatePreferencesData({ browsePageFiltersExpanded: !expanded });
     };
     const view = searchState.views[props.view];
 

--- a/src/renderer/components/pages/BrowsePage.tsx
+++ b/src/renderer/components/pages/BrowsePage.tsx
@@ -1,8 +1,10 @@
 import { englishTranslation } from "@renderer/lang/en";
 import {
+    AdvancedFilter,
     forceSearch,
     selectGame,
     selectPlaylist,
+    setAdvancedFilter,
     stopMusic,
 } from "@renderer/redux/searchSlice";
 import { RootState } from "@renderer/redux/store";
@@ -73,6 +75,7 @@ const mapDispatch = {
     onSelectGame: selectGame,
     forceSearch: forceSearch,
     onStopMusic: stopMusic,
+    onSetAdvancedFilter: setAdvancedFilter,
 };
 
 const connector = connect(mapState, mapDispatch);
@@ -306,6 +309,7 @@ class BrowsePage extends React.Component<
                         onGameLaunchSetup={this.onGameLaunchSetup}
                         onAddAppLaunch={this.onAddAppLaunch}
                         onFavoriteToggle={this.onFavoriteToggle}
+                        onSearchField={this.onSearchField}
                     />
                 </ResizableSidebar>
             </div>
@@ -402,6 +406,28 @@ class BrowsePage extends React.Component<
                 game,
                 userInitiated: true,
             });
+        }
+    };
+
+    onSearchField = (field: keyof AdvancedFilter, value: string): void => {
+        const view = this.props.searchState.views[this.props.gameLibrary];
+        if (!view) {
+            return;
+        }
+        const values = (
+            field === "releaseYear"
+                ? [value.split("-")[0]]
+                : value.split(";").map((s) => s.trim())
+        ).filter((s) => s.length > 0);
+        if (values.length === 0) {
+            return;
+        }
+        this.props.onSetAdvancedFilter({
+            view: this.props.gameLibrary,
+            filter: { ...view.advancedFilter, [field]: values },
+        });
+        if (!this.props.preferencesData.browsePageFiltersExpanded) {
+            updatePreferencesData({ browsePageFiltersExpanded: true });
         }
     };
 

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -1451,6 +1451,10 @@ body {
   white-space: pre;
 }
 
+.browse-right-sidebar--edit-disabled .browse-right-sidebar__searchable {
+  cursor: pointer;
+}
+
 .browse-right-sidebar--edit-disabled .browse-right-sidebar__row--one-line> :last-child {
   flex: 1 1 auto;
   text-overflow: ellipsis;


### PR DESCRIPTION
Clicking Tags, Series, Developer, Publisher, Play Mode or Release Year in the right sidebar applies that value as an advanced filter for the current view, replacing only that field's filter and leaving other fields and the text search intact.

Also auto-expand the filters row when a filter is applied this way if it was collapsed, so the applied filter is visible. To make this reactive, SearchBar now reads the expanded flag from PreferencesContext instead of mount-only local state.