### PR TITLE
fix(build): make universal macOS dmg build succeed and fail loudly

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,17 +130,24 @@ gulp.task("pack", (done) => {
                 },
                 mac: {
                     icon: "./icons/icon.icns",
+                    // Both arch builds ship the full set of sharp/libvips @img
+                    // binaries (arm64 + x64), so every native Mach-O is byte
+                    // identical across them. Tell @electron/universal to keep
+                    // them as-is instead of failing the merge — sharp selects
+                    // the right one at runtime via process.arch.
+                    x64ArchFiles: "**/node_modules/@img/**",
                 },
             },
             targets: targets,
         })
         .then(() => {
             console.log("Pack - Done!");
+            done();
         })
         .catch((error) => {
             console.log("Pack - Error!", error);
-        })
-        .then(done);
+            done(error);
+        });
 });
 
 /* ------ Meta Tasks ------*/


### PR DESCRIPTION
Add x64ArchFiles for @img so @electron/universal keeps the sharp/libvips native binaries as-is instead of erroring when they are byte-identical across the x64 and arm64 builds (sharp picks the right one at runtime).

Also propagate pack errors to the gulp callback so a failed build fails the task and CI instead of silently passing without a .dmg.