### PR TITLE
fix: stop same-titled games from sharing each other's images

### DIFF
--- a/src/renderer/redux/gamesMiddleware.ts
+++ b/src/renderer/redux/gamesMiddleware.ts
@@ -17,12 +17,13 @@ import { initializeViews } from "./searchSlice";
 import { IGameCollection } from "@shared/game/interfaces";
 import { GameCollection } from "@shared/game/GameCollection";
 import {
+    assignGameImages,
     createMusicWatcher,
     createVideosWatcher,
     loadPlatformImages,
     loadPlatformMusic,
     loadPlatformVideos,
-    mapGamesMedia,
+    mapGameVideo,
     mapGamesMusic,
 } from "@renderer/util/media";
 import { createManualsWatcher } from "@renderer/util/addApps";
@@ -173,8 +174,9 @@ async function loadPlatform(platform: string, platformsPath: string, installable
             console.log(`[PERF] ${platform} - Parse games (${platformCollection.games.length} games): ${Date.now() - parseGamesStart}ms`);
 
             const mapMediaStart = Date.now();
+            assignGameImages(platformCollection.games, images);
             for (const game of platformCollection.games) {
-                mapGamesMedia(game, images, videos);
+                mapGameVideo(game, videos);
                 mapGamesMusic(game, music);
             }
             console.log(`[PERF] ${platform} - Map media: ${Date.now() - mapMediaStart}ms`);

--- a/src/renderer/util/media.test.ts
+++ b/src/renderer/util/media.test.ts
@@ -4,8 +4,16 @@ jest.mock("@renderer/redux/gamesSlice", () => ({ updateGame: jest.fn() }));
 jest.mock("chokidar", () => ({ watch: jest.fn(() => ({ on: jest.fn() })) }));
 
 import * as fs from "fs";
-import { GameMusicCollection, GameVideosCollection, IGameInfo } from "@shared/game/interfaces";
-import { convertToGameTitleIndex, getGameTitleIndexFromFilename, mapGamesMedia, mapGamesMusic } from "./media";
+import { GameImagesCollection, GameMusicCollection, GameVideosCollection, IGameInfo } from "@shared/game/interfaces";
+import {
+    assignGameImages,
+    convertToGameTitleIndex,
+    createCategoryImageIndex,
+    getGameTitleIndexFromFilename,
+    indexImage,
+    mapGameVideo,
+    mapGamesMusic,
+} from "./media";
 
 function makeGame(applicationPath: string): IGameInfo {
     return {
@@ -96,7 +104,7 @@ describe("mapGamesMusic", () => {
     });
 });
 
-describe("mapGamesMedia video matching", () => {
+describe("mapGameVideo", () => {
     beforeAll(() => {
         (window as any).External = { config: { fullExodosPath: "/test" } };
     });
@@ -118,7 +126,7 @@ describe("mapGamesMedia video matching", () => {
         const game = makeGame("eXo\\eXoDOS\\!dos\\quake\\Quake (1996).bat");
         game.platform = "MS-DOS";
         const videos = videosFor("Quake (1996).mp4");
-        mapGamesMedia(game, {}, videos);
+        mapGameVideo(game, videos);
         expect(game.media.video).toBe(
             `Videos/MS-DOS/${encodeURIComponent("Quake (1996).mp4")}`
         );
@@ -130,7 +138,7 @@ describe("mapGamesMedia video matching", () => {
         );
         game.platform = "DREAMM";
         const videos = videosFor("Star Wars - X-Wing Vs. TIE Fighter Gold (2000).mp4");
-        mapGamesMedia(game, {}, videos);
+        mapGameVideo(game, videos);
         expect(game.media.video).toBe(
             `Videos/DREAMM/${encodeURIComponent("Star Wars - X-Wing Vs. TIE Fighter Gold (2000).mp4")}`
         );
@@ -220,5 +228,192 @@ describe("image filename to XML title round-trip", () => {
         ["3-D Ultra Pinball-01.png",                   "3-D Ultra Pinball: Creep Night"],
     ])("does NOT match file '%s' to game '%s'", (filename, gameTitle) => {
         expect(matches(filename, gameTitle)).toBe(false);
+    });
+});
+
+describe("assignGameImages", () => {
+    // Filenames below are taken verbatim from the eXoDOS collection.
+    const GAMEPLAY = "Screenshot - Gameplay";
+    const TITLE_SHOT = "Screenshot - Game Title";
+
+    function collectionOf(files: Record<string, string[]>): GameImagesCollection {
+        const collection: GameImagesCollection = {};
+        for (const [category, filenames] of Object.entries(files)) {
+            const index = createCategoryImageIndex();
+            for (const filename of filenames) {
+                indexImage(index, filename, filename);
+            }
+            collection[category] = index;
+        }
+        return collection;
+    }
+
+    function gameOf(title: string, id: string): IGameInfo {
+        const game = makeGame("eXo\\eXoDemoScn\\!demoscn\\x\\x (1993).bat");
+        game.title = title;
+        game.id = id;
+        game.platform = "eXoDemoScene";
+        game.media = { images: {}, video: "" };
+        return game;
+    }
+
+    function assign(
+        games: [title: string, id: string][],
+        files: Record<string, string[]>
+    ): Record<string, IGameInfo> {
+        const gameInfos = games.map(([title, id]) => gameOf(title, id));
+        assignGameImages(gameInfos, collectionOf(files));
+        return Object.fromEntries(gameInfos.map((g) => [g.id, g]));
+    }
+
+    it("gives GUID-suffixed files to the matching game and bare files to its sibling", () => {
+        const games = assign(
+            [
+                ["Creation", "0f2d7945-e89f-4ece-aa98-ae5836b4d145"],
+                ["Creation", "408653ba-be70-478c-9e7d-7bf27dd4e907"],
+            ],
+            {
+                [GAMEPLAY]: [
+                    "Creation-01.png",
+                    "Creation.408653ba-be70-478c-9e7d-7bf27dd4e907-01.png",
+                    "Creation.408653ba-be70-478c-9e7d-7bf27dd4e907-02.png",
+                ],
+            }
+        );
+
+        expect(games["0f2d7945-e89f-4ece-aa98-ae5836b4d145"].media.images[GAMEPLAY])
+        .toEqual(["Creation-01.png"]);
+        expect(games["408653ba-be70-478c-9e7d-7bf27dd4e907"].media.images[GAMEPLAY])
+        .toEqual([
+            "Creation.408653ba-be70-478c-9e7d-7bf27dd4e907-01.png",
+            "Creation.408653ba-be70-478c-9e7d-7bf27dd4e907-02.png",
+        ]);
+    });
+
+    it("does not fall back to bare-title files in categories where the GUID-named game has none", () => {
+        const games = assign(
+            [
+                ["Evil", "3621627c-4517-4369-bf93-5366cab20dcf"],
+                ["Evil", "6c12e926-eb57-4439-8085-9d6239335d56"],
+            ],
+            {
+                [GAMEPLAY]: [
+                    "Evil.6c12e926-eb57-4439-8085-9d6239335d56-01.png",
+                ],
+                [TITLE_SHOT]: ["Evil-01.png"],
+            }
+        );
+
+        const guidNamed = games["6c12e926-eb57-4439-8085-9d6239335d56"];
+        expect(guidNamed.media.images[GAMEPLAY]).toEqual([
+            "Evil.6c12e926-eb57-4439-8085-9d6239335d56-01.png",
+        ]);
+        expect(guidNamed.media.images[TITLE_SHOT]).toBeUndefined();
+        expect(games["3621627c-4517-4369-bf93-5366cab20dcf"].media.images[TITLE_SHOT])
+        .toEqual(["Evil-01.png"]);
+    });
+
+    it.each([
+        ["Alive", "Alive-01.png", "Alive!", "Alive!-01.png"],
+        ["Rip-Off", "Rip-Off-01.png", "RipOff", "RipOff-01.png"],
+        ["Why", "Why-01.png", "Why?", "Why_-01.png"],
+        ["Snow-Tro", "Snow-Tro-01.png", "Snowtro", "Snowtro-01.png"],
+        ["-", "--01.png", "?", "_-01.png"],
+    ])(
+        "keeps '%s' and '%s' apart despite punctuation",
+        (titleA, fileA, titleB, fileB) => {
+            const games = assign(
+                [
+                    [titleA, "id-a"],
+                    [titleB, "id-b"],
+                ],
+                { [GAMEPLAY]: [fileA, fileB] }
+            );
+
+            expect(games["id-a"].media.images[GAMEPLAY]).toEqual([fileA]);
+            expect(games["id-b"].media.images[GAMEPLAY]).toEqual([fileB]);
+        }
+    );
+
+    it("keeps titles that differ only in casing apart", () => {
+        const games = assign(
+            [
+                ["Warp", "f3c72f25-ce0b-4a9f-8831-b45902307709"],
+                ["WARP", "2eb4d438-81e0-431b-a080-46dcd2a1e746"],
+            ],
+            { [GAMEPLAY]: ["Warp-01.png", "WARP-02.png"] }
+        );
+
+        expect(games["f3c72f25-ce0b-4a9f-8831-b45902307709"].media.images[GAMEPLAY])
+        .toEqual(["Warp-01.png"]);
+        expect(games["2eb4d438-81e0-431b-a080-46dcd2a1e746"].media.images[GAMEPLAY])
+        .toEqual(["WARP-02.png"]);
+    });
+
+    it("treats a trailing release year as a disambiguator", () => {
+        const games = assign(
+            [
+                ["SSI Spring Catalog (1984)", "id-84"],
+                ["SSI Spring Catalog (1985)", "id-85"],
+            ],
+            {
+                [GAMEPLAY]: [
+                    "SSI Spring Catalog (1984)-01.jpg",
+                    "SSI Spring Catalog (1985)-01.jpg",
+                ],
+            }
+        );
+
+        expect(games["id-84"].media.images[GAMEPLAY]).toEqual([
+            "SSI Spring Catalog (1984)-01.jpg",
+        ]);
+        expect(games["id-85"].media.images[GAMEPLAY]).toEqual([
+            "SSI Spring Catalog (1985)-01.jpg",
+        ]);
+    });
+
+    it("still matches loosely when no game claims the file by its exact name", () => {
+        const games = assign([["3-D Ultra Pinball", "id-a"]], {
+            [GAMEPLAY]: ["3D Ultra Pinball (1995).png"],
+        });
+
+        expect(games["id-a"].media.images[GAMEPLAY]).toEqual([
+            "3D Ultra Pinball (1995).png",
+        ]);
+    });
+
+    it("does not hand an ambiguous loose match to either candidate", () => {
+        const games = assign(
+            [
+                ["First", "id-a"],
+                ["First!", "id-b"],
+            ],
+            { [GAMEPLAY]: ["First!-01.png"] }
+        );
+
+        expect(games["id-a"].media.images[GAMEPLAY]).toBeUndefined();
+        expect(games["id-b"].media.images[GAMEPLAY]).toEqual(["First!-01.png"]);
+    });
+
+    it("picks the thumbnail from the game's own images by preference order", () => {
+        const games = assign(
+            [
+                ["Timeout", "1b9eb999-47ee-4835-b777-319f72fa38a2"],
+                ["TimeOut", "97da71eb-c94f-498a-b344-937790ea1350"],
+            ],
+            {
+                "Box - Front": [
+                    "Timeout-01.png",
+                    "TimeOut.97da71eb-c94f-498a-b344-937790ea1350-02.png",
+                ],
+            }
+        );
+
+        expect(games["1b9eb999-47ee-4835-b777-319f72fa38a2"].thumbnailPath)
+        .toBe("Images/eXoDemoScene/Timeout-01.png");
+        expect(games["97da71eb-c94f-498a-b344-937790ea1350"].thumbnailPath)
+        .toBe(
+            "Images/eXoDemoScene/TimeOut.97da71eb-c94f-498a-b344-937790ea1350-02.png"
+        );
     });
 });

--- a/src/renderer/util/media.ts
+++ b/src/renderer/util/media.ts
@@ -1,5 +1,7 @@
 import { deepCopy, extractTitleFromMediaPath, fixSlashes, getRelativePath, removeFileExtension } from "@shared/Util";
 import {
+    CategoryImageIndex,
+    GameImages,
     GameImagesCollection,
     GameMusicCollection,
     GameVideosCollection,
@@ -55,12 +57,7 @@ function getGameTitleForVideo(game: IGameInfo) {
     return removeFileExtension(path.basename(fixSlashes(game.applicationPath)));
 }
 
-export function mapGamesMedia(
-    game: IGameInfo,
-    images: GameImagesCollection,
-    videos: GameVideosCollection
-) {
-    // Load videos
+export function mapGameVideo(game: IGameInfo, videos: GameVideosCollection) {
     const gameName = getGameTitleForVideo(game);
     try {
         if (videos[gameName]) {
@@ -69,50 +66,145 @@ export function mapGamesMedia(
     } catch {
         // Ignore, files don't exist if path isn't forming
     }
+}
 
-    const possibleTitles = [game.title, `${game.title}.${game.id}`];
-    const formattedGameTitles = possibleTitles.map((t) =>
-        convertToGameTitleIndex(t)
-    ) as [string, string];
+/**
+ * Assigns every game its images out of the platform's image collection.
+ *
+ * Works on the whole platform at once because the loose fallback has to know which files
+ * another game already claimed by exact name, and which loose keys more than one game
+ * answers to. eXoDOS disambiguates same-titled games by appending the game's GUID to the
+ * image filename ("Creation-01.png" vs "Creation.408653ba-...-01.png"), so a game that has
+ * any GUID-named image is never allowed to fall back to the bare title - those files
+ * belong to its same-named sibling.
+ */
+export function assignGameImages(
+    games: IGameInfo[],
+    images: GameImagesCollection
+) {
+    const categories = Object.keys(images);
+    const claimed = new Set<string>();
+    const looseKeyOwners = countLooseKeyOwners(games);
+    const pendingCategories = new Map<IGameInfo, string[]>();
 
-    // Load all images
-    for (const category of Object.keys(images)) {
-        const imagesForGame = getImagesFromCollection(
-            images,
-            category,
-            formattedGameTitles
-        );
-        if (imagesForGame) {
-            game.media.images[category] = imagesForGame;
+    for (const game of games) {
+        const qualified = `${game.title}.${game.id}`;
+        const keys = [sanitizeTitleForFilename(qualified)];
+        if (!hasImagesForKey(images, categories, keys[0])) {
+            keys.push(sanitizeTitleForFilename(game.title));
+        }
+
+        const pending: string[] = [];
+        for (const category of categories) {
+            const found = findPreciseImages(images[category], keys);
+            if (found) {
+                assignCategoryImages(game, category, found, claimed);
+            } else {
+                pending.push(category);
+            }
+        }
+        pendingCategories.set(game, pending);
+    }
+
+    for (const game of games) {
+        const qualified = `${game.title}.${game.id}`;
+        const keys = [
+            convertToGameTitleIndexKeepingYear(qualified),
+            convertToGameTitleIndex(qualified),
+            convertToGameTitleIndexKeepingYear(game.title),
+            convertToGameTitleIndex(game.title),
+        ].filter((key) => key && looseKeyOwners.get(key) === 1);
+
+        for (const category of pendingCategories.get(game) ?? []) {
+            const found = findLooseImages(images, category, keys, claimed);
+            if (found) {
+                assignCategoryImages(game, category, found, claimed);
+            }
         }
     }
 
-    // Load thumbnail path
-    for (const preference of thumbnailPreference) {
-        const imagesForGame = getImagesFromCollection(
-            images,
-            preference,
-            formattedGameTitles
-        );
-        if (imagesForGame?.[0]) {
-            game.thumbnailPath = `Images/${game.platform}/${fixSlashes(
-                imagesForGame[0]
-            )}`;
-            return;
+    for (const game of games) {
+        for (const preference of thumbnailPreference) {
+            const thumbnail = game.media.images[preference]?.[0];
+            if (thumbnail) {
+                game.thumbnailPath = `Images/${game.platform}/${fixSlashes(
+                    thumbnail
+                )}`;
+                break;
+            }
         }
     }
 }
 
-function getImagesFromCollection(
+function assignCategoryImages(
+    game: IGameInfo,
+    category: string,
+    imagePaths: string[],
+    claimed: Set<string>
+) {
+    game.media.images[category] = imagePaths;
+    for (const imagePath of imagePaths) {
+        claimed.add(`${category}/${imagePath}`);
+    }
+}
+
+function countLooseKeyOwners(games: IGameInfo[]): Map<string, number> {
+    const owners = new Map<string, Set<string>>();
+    for (const game of games) {
+        for (const title of [game.title, `${game.title}.${game.id}`]) {
+            const keys = [
+                convertToGameTitleIndexKeepingYear(title),
+                convertToGameTitleIndex(title),
+            ];
+            for (const key of new Set(keys)) {
+                if (!key) continue;
+                const gameIds = owners.get(key) ?? new Set<string>();
+                gameIds.add(game.id);
+                owners.set(key, gameIds);
+            }
+        }
+    }
+    return new Map(
+        [...owners].map(([key, gameIds]) => [key, gameIds.size])
+    );
+}
+
+function hasImagesForKey(
+    images: GameImagesCollection,
+    categories: string[],
+    key: string
+): boolean {
+    return categories.some(
+        (category) =>
+            images[category].exact[key] ||
+            images[category].insensitive[key.toUpperCase()]
+    );
+}
+
+function findPreciseImages(
+    index: CategoryImageIndex,
+    keys: string[]
+): string[] | null {
+    for (const key of keys) {
+        const found = index.exact[key] ?? index.insensitive[key.toUpperCase()];
+        if (found) return found;
+    }
+    return null;
+}
+
+function findLooseImages(
     images: GameImagesCollection,
     category: string,
-    formattedGameTitles: [string, string]
-) {
-    const imagesForGame =
-        images?.[category]?.[formattedGameTitles[0]] ??
-        images?.[category]?.[formattedGameTitles[1]] ??
-        null;
-    return imagesForGame;
+    keys: string[],
+    claimed: Set<string>
+): string[] | null {
+    for (const key of keys) {
+        const found = images[category].loose[key]?.filter(
+            (imagePath) => !claimed.has(`${category}/${imagePath}`)
+        );
+        if (found?.length) return found;
+    }
+    return null;
 }
 
 // Finds a list of all game images, returned in a map where the key is the type of image, and the value is an array of filenames
@@ -131,27 +223,18 @@ export async function loadPlatformImages(
             withFileTypes: true,
         });
         for (const dir of rootFolders.filter((f) => f.isDirectory())) {
-            collection[dir.name] = {}; // Initialize the image category
+            const index = createCategoryImageIndex();
+            collection[dir.name] = index;
 
             const folderPath = path.join(platformImagesPath, dir.name);
 
             for (const fileInfo of walkSync(folderPath)) {
                 try {
-                    const rawTitleFromFilename = getGameTitleIndexFromFilename(
-                        fileInfo.filename
+                    indexImage(
+                        index,
+                        fileInfo.filename,
+                        createImagePath(platformImagesPath, fileInfo)
                     );
-
-                    if (!rawTitleFromFilename) continue;
-                    const titleIndex =
-                        convertToGameTitleIndex(rawTitleFromFilename);
-                    if (!collection?.[dir.name]?.[titleIndex]) {
-                        collection[dir.name][titleIndex] = [];
-                    }
-                    const imagePath = createImagePath(
-                        platformImagesPath,
-                        fileInfo
-                    );
-                    collection[dir.name][titleIndex].push(imagePath);
                 } catch (err) {
                     console.error(
                         `Error while processing ${fileInfo.filename} file. Skipping. Error: ${err}`
@@ -174,6 +257,39 @@ function createImagePath(platformImagePath: string, fileInfo: IFileInfo) {
     );
 }
 
+export function createCategoryImageIndex(): CategoryImageIndex {
+    return { exact: {}, insensitive: {}, loose: {} };
+}
+
+export function indexImage(
+    index: CategoryImageIndex,
+    filename: string,
+    imagePath: string
+) {
+    const titleFromFilename = getGameTitleIndexFromFilename(filename);
+    if (!titleFromFilename) return;
+
+    const sanitized = sanitizeTitleForFilename(titleFromFilename);
+    pushImage(index.exact, sanitized, imagePath);
+    pushImage(index.insensitive, sanitized.toUpperCase(), imagePath);
+
+    const looseKeys = new Set([
+        convertToGameTitleIndexKeepingYear(titleFromFilename),
+        convertToGameTitleIndex(titleFromFilename),
+    ]);
+    for (const looseKey of looseKeys) {
+        pushImage(index.loose, looseKey, imagePath);
+    }
+}
+
+function pushImage(index: GameImages, key: string, imagePath: string) {
+    if (!key) return;
+    if (!index[key]) {
+        index[key] = [];
+    }
+    index[key].push(imagePath);
+}
+
 export function getGameTitleIndexFromFilename(filename: string): string | null {
     const nameWithoutExt = filename.replace(/\.[^.]+$/, "");
     const nameWithoutNum = nameWithoutExt.replace(/-\d{2,}$/, "");
@@ -181,13 +297,27 @@ export function getGameTitleIndexFromFilename(filename: string): string | null {
     return title || null;
 }
 
-export function convertToGameTitleIndex(title: string): string {
+// Mirrors how LaunchBox writes image filenames: characters Windows forbids in a filename
+// (plus the apostrophe) become an underscore, everything else is kept verbatim.
+export function sanitizeTitleForFilename(title: string): string {
     return title
-    .replace(/\s*\(\d{4}\)\s*$/, "")
+    .replace(/[\\/:*?"<>|']/g, "_")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function convertToGameTitleIndexKeepingYear(title: string): string {
+    return title
     .replace(/[^a-zA-Z0-9 ]/g, "")
     .replace(/\s+/g, " ")
     .trim()
     .toUpperCase();
+}
+
+export function convertToGameTitleIndex(title: string): string {
+    return convertToGameTitleIndexKeepingYear(
+        title.replace(/\s*\(\d{4}\)\s*$/, "")
+    );
 }
 
 export function* walkSync(dir: string): IterableIterator<IFileInfo> {

--- a/src/shared/game/interfaces.ts
+++ b/src/shared/game/interfaces.ts
@@ -69,8 +69,15 @@ export type GameMedia = {
     video: string;
 };
 
+/** The three lookup indexes an image category is keyed by, from strictest to loosest. */
+export type CategoryImageIndex = {
+    exact: GameImages; // LaunchBox-sanitized filename stem, case preserved
+    insensitive: GameImages; // same, uppercased
+    loose: GameImages; // punctuation stripped, keyed both with and without a trailing (Year)
+};
+
 export type GameImagesCollection = {
-    [key: string]: GameImages; // "Box - Front" - "<GameTitle>" - "<FilePath>"
+    [key: string]: CategoryImageIndex; // "Box - Front" - index - "<GameTitle>" - "<FilePath>"
 };
 
 export type GameVideosCollection = {


### PR DESCRIPTION
Image matching normalized titles by stripping all punctuation, so Alive/Alive!, Rip-Off/RipOff, Why/Why? and Timeout/TimeOut collapsed to one index and each got the union of both image sets. Titles made only of punctuation (? and -) both normalized to an empty key and shared a bucket. The lookup also tried the bare title before "title.id", so the GUID-suffixed filenames eXoDOS uses to disambiguate duplicates were never reached. Stripping a trailing (Year) merged Action Fighter (1989) with (1994) and SSI Spring Catalog (1984..1987) the same way.

Index each category three ways - LaunchBox-sanitized exact, the same uppercased, and the previous loose form - and assign images per platform in two passes: exact names first (a game with any GUID-named image never falls back to the bare title, those files belong to its sibling), then a loose fallback restricted to files nobody claimed exactly and keys exactly one game answers to.

Against the eXoDOS collection this takes games showing another game's artwork from 109 to 0 in eXoDemoScene, 291 to 0 in MS-DOS and 72 to 0 in MS-DOS Catalogs, while attributing more files than before.